### PR TITLE
Fix bug 3

### DIFF
--- a/markdown.nim
+++ b/markdown.nim
@@ -1,4 +1,4 @@
-import re, sha1, strutils
+import re, sha1, strutils, future
 
 type
   Markdown* = string
@@ -23,10 +23,9 @@ let
     """<b>$1</b>""")
   strikethrough = (re""" ~~ ( (?:(?!~~) .)++ ) ~~ """,
     """<del>$1</del>""")
-  h1 = (re("""^ \#    [[:blank:]]*+ ([^#\n\r]++) $""", {reExtended, reStudy, reMultiLine}), """<h1>$1</h1>""")
-  h2 = (re("""^ \#{2} [[:blank:]]*+ ([^#\n\r]++) $""", {reExtended, reStudy, reMultiLine}), """<h2>$1</h2>""")
-  h3 = (re("""^ \#{3} [[:blank:]]*+ ([^#\n\r]++) $""", {reExtended, reStudy, reMultiLine}), """<h3>$1</h3>""")
-  h4 = (re("""^ \#{4} [[:blank:]]*+ ([^#\n\r]++) $""", {reExtended, reStudy, reMultiLine}), """<h4>$1</h4>""")
+  headers = lc[(re("""^ \#{""" & $x & """}    [[:blank:]]*+ ([^#\n\r]++) $""",
+                {reExtended, reStudy, reMultiLine}),
+               "<h" & $x & ">$1</h" & $x & ">") | (x <- 1..6), tuple[r: Regex, replacement: string]]
 
   # Replaced with SHA hash
   blockCode = re(""" ^```(?:.*$) ([\n\r]|.)+ ^``` """,
@@ -105,7 +104,7 @@ proc toHtml*(md: Markdown): string =
     var strippedMatch = match.replace(blockQuoteLeadingSymbol)
     md = md.replace(match, "<blockquote>\n" & strippedMatch & "\n</blockquote>")
 
-  md = md.parallelReplace([url, link, image, italics, bold, strikethrough, h1, h2, h3, h4])
+  md = md.parallelReplace(@[url, link, image, italics, bold, strikethrough] & headers)
 
   # XXX nested lists
 


### PR DESCRIPTION
Handle headers up to `<h6>`.

---

Unlike the suggestion in bug 3, this is a very high quality patch that uses for comprentions to generate the appropriate expressions.